### PR TITLE
failing case

### DIFF
--- a/app/constants/build_constants.js
+++ b/app/constants/build_constants.js
@@ -1,0 +1,18 @@
+var imageRoot = "/app/images/";
+var fontRoot = "/app/fonts/";
+var styleRoot = "/app/style/";
+var mobileDir = "Mobile_Assets/";
+var webDir = "Client_Assets/";
+var webPath = imageRoot + webDir;
+var mobilePath = imageRoot + mobileDir;
+var demoPath = "http://url1.com/";
+var devPath = "https://url2.net";
+// these variables are injected into both Javascript and SCSS.
+module.exports = {
+  templateDir: "jsx-templates/foxwoods/",
+  styleDir: "style/foxwoods/",
+  webPath: imageRoot + webDir,
+  mobilePath: imageRoot + mobileDir,
+  _facebookEnabled: false,
+  WebpackAPIRoot: devPath
+}

--- a/app/game-wrappers/gamesInterface.js
+++ b/app/game-wrappers/gamesInterface.js
@@ -11,6 +11,8 @@ var Actions = keyMirror({
   ERROR_DESCRIPTION: null
 });
 
+console.log(WebpackAPIRoot);
+
 /**
  * @name buildAction
  * @param suppliedType string

--- a/wallaby.js
+++ b/wallaby.js
@@ -4,9 +4,13 @@ var appRootPath = path.resolve(__dirname, "app");
 var modulePath = path.resolve(appRootPath, 'vendor');
 var wallabyWebpack = require('wallaby-webpack');
 var babel = require('babel-core');
-
+var buildConstants = require('./app/constants/build_constants');
+/*for(var j=0;j<Object.keys(buildConstants).length;j++){
+  buildConstants[Object.keys(buildConstants)[j]] = "'"+buildConstants[Object.keys(buildConstants)[j]]+"'";
+}*/
 var wallabyPostprocessor = wallabyWebpack({
     plugins: [
+      new webpack.DefinePlugin(buildConstants),
       new webpack.IgnorePlugin(/.scss$/)
     ],
     resolve: {
@@ -28,7 +32,8 @@ var wallabyPostprocessor = wallabyWebpack({
 module.exports = function (wallaby) {
   return {
     env: {
-     runner: "node_modules/phantomjs2-ext/lib/phantom/bin/phantomjs"
+     //runner: "node_modules/phantomjs2-ext/lib/phantom/bin/phantomjs"
+      runner: "C:\\phantomjs-2.0.0-windows\\bin\\phantomjs.exe"
     },
 
     files: [


### PR DESCRIPTION
- to work around: uncomment the code at the head of wallaby.js
- expected behaviour: it passes through the error to the console in a meaningful way
- observed behaviour: obscure stack trace:

```
Error: Cannot find module '1'
    at app/game-wrappers/gamesInterface-Test.js:3
```
- to witness the exception: open the sandbox page in the browser and see the uncaught exception in the console that points to the actual problem: 

```
Navigated to http://localhost:54551/wallaby_sandbox0.html
gamesInterface.js.1.wbp.js?1453325847821&wallabyFileId=1:51 Uncaught SyntaxError: Unexpected token :
wallaby-webpack.js?1453325847908:1 Uncaught Error: Cannot find module '1's @ wallaby-webpack.js?1453325847908:1rq @ wallaby-webpack.js?1453325847908:1window.__moduleBundler.cache.C:\Users\Karl\.WebStorm12\system\wallaby\projects\1597db1c44a2e580\instrumented\app\game-wrappers\gamesInterface-Test.js @ gamesInterface-Test.js.wbp.js?1453325847798&wallabyFileId=2:3s @ wallaby-webpack.js?1453325847908:1e @ wallaby-webpack.js?1453325847908:1window.__moduleBundler.loadTests @ wallaby-webpack.js?1453325847908:1(anonymous function) @ wallaby_sandbox0.html:13(anonymous function) @ wallaby_sandbox0.html:14
```
